### PR TITLE
fix repeat words

### DIFF
--- a/app/src/main/java/com/example/englishwords/screens/RepeatWordsScreen.kt
+++ b/app/src/main/java/com/example/englishwords/screens/RepeatWordsScreen.kt
@@ -88,8 +88,6 @@ fun RepeatWordsScreen(
                         stringResource(id = R.string.text_ifo_about_repeat_words)
                     )
                 }
-                repeatWordsViewModel.getEnglishWordsMap()
-                repeatWordsViewModel.updateTranslateList()
                 CountsGuessWords(repeatWordsViewModel = repeatWordsViewModel)
                 ButtonsEnglishWords(repeatWordsViewModel = repeatWordsViewModel)
             }
@@ -102,6 +100,8 @@ fun CountsGuessWords(repeatWordsViewModel: RepeatWordsViewModel) {
     repeatWordsViewModel.apply {
         val countGuess by guessCount.collectAsState()
         val noCountGuess by noGuessCount.collectAsState()
+        getEnglishWordsMap()
+        updateTranslateList()
         Row(
             Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
Пофиксил баг, который мешал обновлению слов на экране. Т.е после нажатия на один из вариантов не менялось слово и сварианты перевода на кнопках.