### PR TITLE
 Исправление бага с радомизацией списка слов

### DIFF
--- a/app/src/main/java/com/example/englishwords/viewmodel/RepeatWordsViewModel.kt
+++ b/app/src/main/java/com/example/englishwords/viewmodel/RepeatWordsViewModel.kt
@@ -38,12 +38,11 @@ class RepeatWordsViewModel @Inject constructor(var dbManager: DbManager) : ViewM
             if (!emptyDataBase) {
                 val countWords = daoData.checkWordsTable()
                 if (countWords > 3) {
-                  launch {
-                      englishWordsListMutable.value = daoData.readRandomWords()
-                      onCloseProgress()
-                  }
-                }
-                else {
+                    launch {
+                        englishWordsListMutable.value = daoData.readRandomWords()
+                        onCloseProgress()
+                    }
+                } else {
                     onCloseProgress()
                     onOpenDialogClicked()
                 }
@@ -56,7 +55,7 @@ class RepeatWordsViewModel @Inject constructor(var dbManager: DbManager) : ViewM
     suspend fun createShuffleTranslateList() =
         withContext(Dispatchers.IO) {
             onShowProgress()
-            val listTranscription = englishWordsListMutable.value
+            val listTranscription = englishWordsListMutable.value.toMutableList()
             shuffleWordsListMutable.value = listTranscription.apply { shuffle() }
             onCloseProgress()
         }
@@ -65,8 +64,8 @@ class RepeatWordsViewModel @Inject constructor(var dbManager: DbManager) : ViewM
     fun guessWord(word: Word): Boolean {
         englishWordsListMutable.value
             .let {
-                    if (it.first().wordEnglish == word.wordEnglish) {
-                        return true
+                if (it.first().wordEnglish == word.wordEnglish) {
+                    return true
                 }
             }
         return false


### PR DESCRIPTION
Была проблема, после того как мы получили 4 слова для использовании их в разделе "Повторения " и хотим создать еще один лист, но уже с перемешанными 4-мя слова. Список с shuffle словами присваивался изначальному списку и поэтому перевод слова всегда стоял первым.  

Ошибка была в том, что я перемешивал изначальный список, а не инициализировал новый и уже применял shuffle.
Решил багу с помощью добавления .toMutableList() к englishWordsListMutable.value., чтобы получить изначальный лист и его уже перемешивать.

до
val listTranscription = englishWordsListMutable.value
после 
val listTranscription = englishWordsListMutable.value.toMutableList()